### PR TITLE
Add extra metadata to the UI

### DIFF
--- a/Discosaur/MainWindow.xaml.cs
+++ b/Discosaur/MainWindow.xaml.cs
@@ -9,7 +9,7 @@ public sealed partial class MainWindow : Window
 {
     private const int DefaultWidth = 580;
     private const int ExpandedHeight = 1200;
-    private const int CollapsedHeight = 770;
+    private const int CollapsedHeight = 800;
 
     public MainWindow()
     {

--- a/Discosaur/Models/Track.cs
+++ b/Discosaur/Models/Track.cs
@@ -10,7 +10,16 @@ public class Track
     public string? Artist { get; set; }
     public string? AlbumTitle { get; set; }
     public uint? TrackNumber { get; set; }
+
+    public string TrackNumberDisplay => TrackNumber == null ? "" : $"#{TrackNumber}";
     public uint? Year { get; set; }
     public string? Genre { get; set; }
     public TimeSpan? Duration { get; set; }
+
+    public string DurationDisplay => Duration switch
+    {
+        null => "",
+        { Hours: > 0 } d => d.ToString(@"h\:mm\:ss"),
+        { } d => d.ToString(@"m\:ss")
+    };
 }

--- a/Discosaur/Views/AlbumView.xaml
+++ b/Discosaur/Views/AlbumView.xaml
@@ -18,7 +18,23 @@
                         DoubleTapped="Track_DoubleTapped"
                         Background="Transparent"
                         Padding="8,4">
-                        <TextBlock Text="{x:Bind Title}" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0"
+                                       Margin="0,0,12,0"
+                                       Foreground="#999999"
+                                       Text="{x:Bind TrackNumberDisplay}" />
+                            <TextBlock Grid.Column="1"
+                                       Text="{x:Bind Title}"
+                                       TextTrimming="CharacterEllipsis" />
+                            <TextBlock Grid.Column="2"
+                                       Text="{x:Bind DurationDisplay}" />
+                        </Grid>
                     </Border>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>

--- a/Discosaur/Views/Player.xaml
+++ b/Discosaur/Views/Player.xaml
@@ -14,13 +14,18 @@
     </UserControl.Resources>
 
     <StackPanel Padding="8,4,8,4" Spacing="4">
-        <TextBlock
-            x:Name="TrackNameText"
-            Text="No track playing"
-            FontSize="14"
-            HorizontalAlignment="Center"
-            TextTrimming="CharacterEllipsis"
-            MaxLines="1" />
+        <TextBlock x:Name="TrackNameText"
+                   Text="No track playing"
+                   FontSize="14"
+                   FontFamily="Nirmala UI"
+                   TextTrimming="CharacterEllipsis"
+                   MaxLines="1" />
+        <TextBlock x:Name="BandNameText"
+                   Text=""
+                   FontSize="12"
+                   TextTrimming="CharacterEllipsis"
+                   Foreground="#999999"
+                   MaxLines="1" />
 
         <!-- Progress bar with time labels -->
         <Grid>

--- a/Discosaur/Views/Player.xaml.cs
+++ b/Discosaur/Views/Player.xaml.cs
@@ -59,6 +59,31 @@ public sealed partial class Player : UserControl
     private void UpdateTrackName()
     {
         TrackNameText.Text = ViewModel.CurrentTrack?.Title ?? "No track playing";
+        BandNameText.Text = GenerateBandAlbumName();
+    }
+
+    private string GenerateBandAlbumName()
+    {
+        if (ViewModel.CurrentTrack == null) return string.Empty;
+
+        var bandName = ViewModel.CurrentTrack.Artist;
+        var albumName = ViewModel.CurrentTrack.AlbumTitle;
+
+        if (bandName != null && albumName != null)
+        {
+            return $"{bandName}: {albumName}";
+        }
+        else if (bandName != null)
+        {
+            return bandName;
+        }
+        else if (albumName != null)
+        {
+            return albumName;
+        } else
+        {
+            return string.Empty;
+        }
     }
 
     private void UpdateTooltips()


### PR DESCRIPTION
## Description

Add extra metadata:

- add band name/album name to the player interface
- add track number
- add track duration

## Reference

Close https://github.com/Bloomca/Discosaur/issues/15